### PR TITLE
fix middleware config

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -32,6 +32,7 @@ export function middleware(request:NextRequest) {
 
     export const config = {
       matcher: [
-        "/((?!api|_next|favicon.ico).*)", // ⬅️ این خط خیلی مهمه
+#        "/((?!api|_next|favicon.ico).*)", // ⬅️ این خط خیلی مهمه
+"/((?!api|_next|favicon\\.ico|.*\\..*).*)"
       ],
     };


### PR DESCRIPTION
Debugging workflow:
First, I tested the image src which is "/asset/babi.jpg", since the "/asset/babi.jpg" equals "http://localhost:3000/asset/babi.jpg", I tried "http://localhost:3000/asset/babi.jpg" on the browser, I figured out the next server is redirecting the route into "http://localhost:3000/en/asset/babi.jpg" (the "/en" added), which means something is breaking the url that related to localization config. then I tried to find the localization config and I suspected to middleware, finally I asked gpt:
https://chatgpt.com/share/67fa31f7-c2ec-800f-b0ae-6a9893746288
